### PR TITLE
ISSUE-11: Path for framework composer packages is generated incorrectly

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Generates patches that can be applied for Magento 2 which was installed from the composer.
 
 ## Requirements
-* PHP-CLI 5.3+
+* PHP-CLI 5.4+
 
 ## Installation
 * Clone this repository into your own folder

--- a/convert-for-composer.php
+++ b/convert-for-composer.php
@@ -1,28 +1,46 @@
 #!/usr/bin/env php
 <?php
+
+/**
+ * Compatibility confirmed for Magento <= 2.2.4
+ *
+ * Class Converter
+ */
 class Converter 
 {
-    const MODULE            = 'Module';
-    const ADMINHTML_DESIGN  = 'AdminhtmlDesign';
-    const FRONTEND_DESIGN   = 'FrontendDesign';
-    const LIBRARY           = 'Library';
+    const MODULE                = 'Module';
+    const ADMINHTML_DESIGN      = 'AdminhtmlDesign';
+    const FRONTEND_DESIGN       = 'FrontendDesign';
+    const LIBRARY_AMPQ          = 'LibraryAmpq';
+    const LIBRARY_BULK          = 'LibraryBulk';
+    const LIBRARY_FOREIGN_KEY   = 'LibraryForeignKey';
+    const LIBRARY_MESSAGE_QUEUE = 'LibraryMessageQueue';
+    const LIBRARY               = 'Library';
 
-    protected $nonComposerPath = array(
+    protected $nonComposerPath  = [
         self::MODULE                => 'app/code/Magento/',
         self::ADMINHTML_DESIGN      => 'app/design/adminhtml/Magento/',
         self::FRONTEND_DESIGN       => 'app/design/frontend/Magento/',
-        self::LIBRARY               => 'lib/internal/Magento/'
-    );
-    protected $composerPath    = array(
+        self::LIBRARY_AMPQ          => 'lib/internal/Magento/Framework/Amqp/',
+        self::LIBRARY_BULK          => 'lib/internal/Magento/Framework/Bulk/',
+        self::LIBRARY_FOREIGN_KEY   => 'lib/internal/Magento/Framework/ForeignKey/',
+        self::LIBRARY_MESSAGE_QUEUE => 'lib/internal/Magento/Framework/MessageQueue/',
+        self::LIBRARY               => 'lib/internal/Magento/Framework/'
+    ];
+    protected $composerPath     = [
         self::MODULE                => 'vendor/magento/module-',
         self::ADMINHTML_DESIGN      => 'vendor/magento/theme-adminhtml-',
         self::FRONTEND_DESIGN       => 'vendor/magento/theme-frontend-',
-        self::LIBRARY               => 'vendor/magento/'
-    );
+        self::LIBRARY_AMPQ          => 'vendor/magento/framework-ampq/',
+        self::LIBRARY_BULK          => 'vendor/magento/framework-bulk/',
+        self::LIBRARY_FOREIGN_KEY   => 'vendor/magento/framework-foreign-key/',
+        self::LIBRARY_MESSAGE_QUEUE => 'vendor/magento/framework-message-queue/',
+        self::LIBRARY               => 'vendor/magento/framework/'
+    ];
 
     protected $options;
 
-    public function __construct($params = array())
+    public function __construct($params = [])
     {
         $filename = $this->parseArgs($params);
         $this->validateFile($filename);
@@ -52,7 +70,7 @@ HELP_TEXT;
         }
 
         array_shift($params);
-        $this->options = getopt('rh', array('help'));
+        $this->options = getopt('rh', ['help']);
         if (isset($this->options['h']) || isset($this->options['help'])) {
             $this->showHelp();
         }
@@ -77,8 +95,7 @@ HELP_TEXT;
 
     public function camelCaseToDashedString($value)
     {
-        return trim(preg_replace_callback('/((?:^|[A-Z])[a-z]+)/',
-            array($this, 'splitCamelCaseByDashes'), $value), '-');
+        return trim(preg_replace_callback('/((?:^|[A-Z])[a-z]+)/', [$this, 'splitCamelCaseByDashes'], $value), '-');
     }
 
     public function splitCamelCaseByDashes($value)
@@ -90,16 +107,23 @@ HELP_TEXT;
     {
         foreach ($this->nonComposerPath as $type => $path) {
             $escapedPath = addcslashes($path, '/');
+            $needProcess = in_array($type, [self::MODULE, self::ADMINHTML_DESIGN, self::FRONTEND_DESIGN]);
 
-            // (     1     )                 (    2   )(         3          )                 (    4   )(        5        )
-            // diff --git a/app/code/Magento/SomeModule/Some/Path/File.ext b/app/code/Magento/SomeModule/Some/Path/File.ext
+            /**
+             * Example:
+             * (     1     )                 (    2    )(        3          )                 (    4    )(       5        )
+             * diff --git a/app/code/Magento/SomeModule/Some/Path/File.ext b/app/code/Magento/SomeModule/Some/Path/File.ext
+             *
+             * (     1     )                                          ()(     3     )                                          ()(    5   )
+             * diff --git a/lib/internal/Magento/Framework/MessageQueue/Config.php b/lib/internal/Magento/Framework/MessageQueue/Config.php
+             */
             $content = preg_replace_callback(
-                '~(^diff --git\s+(?:a\/)?)' . $escapedPath . '([-\w]+)(\/[^\s]+\s+(?:b\/)?)' . $escapedPath . '([-\w]+)(\/[^\s]+)$~m',
-                function ($matches) use ($type) {
+                '~(^diff --git\s+(?:a\/)?)' . $escapedPath . '([-\w]+\/)?([^\s]+\s+(?:b\/)?)' . $escapedPath . '([-\w]+\/)?([^\s]+)$~m',
+                function ($matches) use ($type, $needProcess) {
                     return $matches[1] . $this->composerPath[$type]
-                        . $this->camelCaseToDashedString($matches[2])
+                        . ($needProcess ? $this->camelCaseToDashedString($matches[2]) : $matches[2])
                         . $matches[3] . $this->composerPath[$type]
-                        . $this->camelCaseToDashedString($matches[4])
+                        . ($needProcess ? $this->camelCaseToDashedString($matches[4]) : $matches[4])
                         . $matches[5];
                 },
                 $content
@@ -109,8 +133,9 @@ HELP_TEXT;
             // +++ b/app/code/Magento/SomeModule...
             $content = preg_replace_callback(
                 '~(^(?:---|\+\+\+|Index:)\s+(?:a\/|b\/)?)' . $escapedPath . '([-\w]+)~m',
-                function ($matches) use ($type) {
-                    return $matches[1] . $this->composerPath[$type] . $this->camelCaseToDashedString($matches[2]);
+                function ($matches) use ($type, $needProcess) {
+                    return $matches[1] . $this->composerPath[$type]
+                        . ($needProcess ? $this->camelCaseToDashedString($matches[2]) : $matches[2]);
                 },
                 $content
             );
@@ -126,12 +151,18 @@ HELP_TEXT;
     {
         foreach ($this->composerPath as $type => $path) {
             $escapedPath = addcslashes($path, '/');
-            $needProcess = $type == self::MODULE || $type == self::LIBRARY;
+            $needProcess = $type != self::FRONTEND_DESIGN && $type != self::ADMINHTML_DESIGN;
 
-            // (     1     )               (        2       )(         3          )               (        4       )(        5        )
-            // diff --git a/vendor/magento/module-some-module/Some/Path/File.ext b/vendor/magento/module-some-module/Some/Path/File.ext
+            /**
+             * Example:
+             * (     1     )               (        2        )(         3         )               (        4        )(       5        )
+             * diff --git a/vendor/magento/module-some-module/Some/Path/File.ext b/vendor/magento/module-some-module/Some/Path/File.ext
+             *
+             * (     1     )                                     ()(     3     )                                     ()(    5   )
+             * diff --git a/vendor/magento/framework-message-queue/Config.php b/vendor/magento/framework-message-queue/Config.php
+             */
             $content = preg_replace_callback(
-                '~(^diff --git\s+(?:a\/)?)' . $escapedPath . '([-\w]+)(\/[^\s]+\s+(?:b\/)?)' . $escapedPath . '([-\w]+)(\/[^\s]+)$~m',
+                '~(^diff --git\s+(?:a\/)?)' . $escapedPath . '([-\w]+\/)?([^\s]+\s+(?:b\/)?)' . $escapedPath . '([-\w]+\/)?([^\s]+)$~m',
                 function ($matches) use ($type, $needProcess) {
                     return $matches[1] . $this->nonComposerPath[$type]
                         . ($needProcess ? $this->dashedStringToCamelCase($matches[2]) : $matches[2])


### PR DESCRIPTION
- Added additional mapping for a framework libraries with specific rules for conversion according to 2.2.4 existing composer.json declarations.
- Regex patterns update.
- Php minimal requirement is increased to 5.4